### PR TITLE
fix: Better handling for tokens across multiple categories

### DIFF
--- a/src/apps/random-target.js
+++ b/src/apps/random-target.js
@@ -143,7 +143,7 @@ export class RandomTarget extends FormApplication {
     }
 
     if (selectedTokens.length < 2) {
-      ui.notifications.error('You need to select at least 2 tokens', {});
+      this._sendErrorUINotification();
       return;
     }
 
@@ -199,8 +199,16 @@ export class RandomTarget extends FormApplication {
     }
 
     target.setTarget(true, { releaseOthers: true });
-    ui.notifications.info(`<b>${target.name}</b> targeted`, {});
+    this._sendSuccessUINotification(target);
     canvas.animatePan(target.position);
+  }
+
+  _sendSuccessUINotification(target) {
+    ui.notifications.info(`<b>${target.name}</b> targeted`, {});
+  }
+
+  _sendErrorUINotification() {
+    ui.notifications.error('You need to select at least 2 tokens', {});
   }
 }
 

--- a/src/apps/random-target.js
+++ b/src/apps/random-target.js
@@ -160,7 +160,8 @@ export class RandomTarget extends FormApplication {
 
     html.find('.tab .toggleSelection').change(event => this._computeToggleSelection(html, event));
     html.find('input[type="checkbox"]').change(event => {
-      this._computeTotalSelectionCount(html, event);
+      this._computeSelectionChange(html, event.target.value, event.target.checked);
+      this._computeTotalSelectionCount(html);
       this._computeSubmitState(html);
     });
   }
@@ -191,12 +192,23 @@ export class RandomTarget extends FormApplication {
     return selection;
   }
 
+  _getInputsById(html, tokenId) {
+    return html.find(`[data-group="target-categories"] input[type="checkbox"][value="${tokenId}"]`);
+  }
+
+  _computeSelectionChange(html, tokenId, newState) {
+    // Replicate the selection change in other categories that have the same token
+    this._getInputsById(html, tokenId).each((_, input) => {
+      input.checked = newState;
+    });
+  }
+
   _computeToggleSelection(html, event) {
     const type = event.target.value;
     const newState = event.target.checked;
 
     this._getCheckedInputs(html, { tab: type }).each((_, input) => {
-      input.checked = newState;
+      this._computeSelectionChange(html, input.value, newState);
     });
   }
 


### PR DESCRIPTION
## Details

This PR fixes an issue introduced in the previous release https://github.com/mcavallo/foundry-vtt-random-target/pull/2

- Token selection across multiple categories is now reflected properly
- Validation and total count now is handled properly
- Selections are de-duplicated before they are used
